### PR TITLE
Add support for longer container names

### DIFF
--- a/commands/host/code
+++ b/commands/host/code
@@ -27,5 +27,5 @@ case ${1:-} in
 esac
 
 if [[ ${CODE_CONTAINER+x} ]]; then
-    ${CODE_EXECUTABLE} --folder-uri "vscode-remote://attached-container+$(printf "%s" "${CODE_CONTAINER}" | xxd -p)${CODE_PATH}"
+    ${CODE_EXECUTABLE} --folder-uri "vscode-remote://attached-container+$(printf '%s' $CODE_CONTAINER | xxd -p)${CODE_PATH}"
 fi

--- a/commands/host/code
+++ b/commands/host/code
@@ -27,5 +27,5 @@ case ${1:-} in
 esac
 
 if [[ ${CODE_CONTAINER+x} ]]; then
-    ${CODE_EXECUTABLE} --folder-uri "vscode-remote://attached-container+$(printf '%s' $CODE_CONTAINER | xxd -p)${CODE_PATH}"
+    ${CODE_EXECUTABLE} --folder-uri "vscode-remote://attached-container+$(printf '%s' $CODE_CONTAINER | xxd -p -c 64)${CODE_PATH}"
 fi


### PR DESCRIPTION
## Problem 

Containers with long files were being split when resolving the hex:

```shell
$ print "%s" "ddev-address-d10-playground" | xxd -p
257320646465762d616464726573732d6431302d706c617967726f756e64
0a
```

## Solution

This PR resolves that issue by increasing the octels per line from `16` to `64`.

```shell
$ print "%s" "ddev-address-d10-playground" | xxd -c64 -p
257320646465762d616464726573732d6431302d706c617967726f756e640a
```

Fixes #1

See [xxd](https://manpages.debian.org/unstable/xxd/xxd.1.en.html)
