### PR TITLE
Improve unix support

### DIFF
--- a/commands/host/code
+++ b/commands/host/code
@@ -27,5 +27,5 @@ case ${1:-} in
 esac
 
 if [[ ${CODE_CONTAINER+x} ]]; then
-    ${CODE_EXECUTABLE} --folder-uri "vscode-remote://attached-container+$(printf '%s' $CODE_CONTAINER | xxd -p -c 64)${CODE_PATH}"
+    ${CODE_EXECUTABLE} --folder-uri "vscode-remote://attached-container+$(printf "$CODE_CONTAINER" | od -A n -t x1 | sed 's/ *//g' | tr -d '\n')${CODE_PATH}"
 fi


### PR DESCRIPTION
Improve cross-dristro support.

> "od", "sed" AND "tr" all follow the POSIX standard, making sure, the command works on a wide variety of UNIX derivatives (xxd doesn't)

[Original comment](https://github.com/microsoft/vscode-remote-release/issues/5278#issuecomment-1628405141)

ChatGPT says `xxd` is avialble on most distro, but may not be "some minimal or specialized distributions".