### PR TITLE
docs: fix: test badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
-[![tests](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml)
+[![tests](https://github.com/tyler36/ddev-vscode-devcontainer/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-addon-template/actions/workflows/tests.yml)
 [![last commit](https://img.shields.io/github/last-commit/tyler36/ddev-vscode-devcontainer)](https://github.com/tyler36/ddev-vscode-devcontainer/commits)
 [![release](https://img.shields.io/github/v/release/tyler36/ddev-vscode-devcontainer)](https://github.com/tyler36/ddev-vscode-devcontainer/releases/latest)
 


### PR DESCRIPTION
## Issue

The test badge points to the add-on template.

## Solution

This PR updates the test badge to point to [this repo](https://github.com/tyler36/ddev-vscode-devcontainer).