### PR TITLE
Sync user-specific git configs into dev container

### DIFF
--- a/commands/host/code
+++ b/commands/host/code
@@ -14,6 +14,7 @@ case ${1:-} in
 -d | -db | --database)
     CODE_CONTAINER="ddev-${DDEV_PROJECT}-db"
     CODE_PATH=$HOME
+    SERVICE="db"
     ;;
 --) # End of all options.
     ;;
@@ -23,9 +24,33 @@ case ${1:-} in
 *) # Default case
     CODE_CONTAINER="ddev-${DDEV_PROJECT}-web"
     CODE_PATH=/var/www/html
+    SERVICE="web"
     ;;
 esac
 
 if [[ ${CODE_CONTAINER+x} ]]; then
+    # Start DDEV, if not running.
+    if [ $DDEV_PROJECT_STATUS != "running" ]; then
+        ddev start
+    fi
+    
+    # Remove DDEV's default .gitconfig file to allow DEV Containers extension to perform default behavior. https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials
+    if [ -e $HOME/.gitconfig ] && ddev exec --quiet --service $SERVICE command -v git > /dev/null 2>&1; then
+        ddev exec --quiet --service $SERVICE rm -f $HOME/.gitconfig
+    fi
+    
     ${CODE_EXECUTABLE} --folder-uri "vscode-remote://attached-container+$(printf "$CODE_CONTAINER" | od -A n -t x1 | sed 's/ *//g' | tr -d '\n')${CODE_PATH}"
+
+    # Wait for VSCode to finish copying .gitconfig and then re-add DDEV default configs.
+    if [ -e $HOME/.gitconfig ] && ddev exec --quiet --service $SERVICE command -v git > /dev/null 2>&1; then
+        COUNT=0
+        MAX_COUNT=5
+        until ddev exec --service $SERVICE "[ -e $HOME/.gitconfig ]" 2> /dev/null || [ $COUNT -gt $MAX_COUNT ]; do
+            ((COUNT=$COUNT+1))
+            sleep 1
+        done
+
+        ddev exec --service $SERVICE git config --global core.autocrlf input
+        ddev exec --service $SERVICE git config --global safe.directory "\*"
+    fi
 fi

--- a/commands/host/code
+++ b/commands/host/code
@@ -30,27 +30,27 @@ esac
 
 if [[ ${CODE_CONTAINER+x} ]]; then
     # Start DDEV, if not running.
-    if [ $DDEV_PROJECT_STATUS != "running" ]; then
+    if [ "$DDEV_PROJECT_STATUS" != "running" ]; then
         ddev start
     fi
     
     # Remove DDEV's default .gitconfig file to allow DEV Containers extension to perform default behavior. https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials
-    if [ -e $HOME/.gitconfig ] && ddev exec --quiet --service $SERVICE command -v git > /dev/null 2>&1; then
-        ddev exec --quiet --service $SERVICE rm -f $HOME/.gitconfig
+    if [ -e "$HOME"/.gitconfig ] && ddev exec --quiet --service "$SERVICE" command -v git > /dev/null 2>&1; then
+        ddev exec --quiet --service "$SERVICE" rm -f "$HOME"/.gitconfig
     fi
     
-    ${CODE_EXECUTABLE} --folder-uri "vscode-remote://attached-container+$(printf "$CODE_CONTAINER" | od -A n -t x1 | sed 's/ *//g' | tr -d '\n')${CODE_PATH}"
+    ${CODE_EXECUTABLE} --folder-uri "vscode-remote://attached-container+$(printf "%s" "$CODE_CONTAINER" | od -A n -t x1 | sed 's/ *//g' | tr -d '\n')${CODE_PATH}"
 
     # Wait for VSCode to finish copying .gitconfig and then re-add DDEV default configs.
-    if [ -e $HOME/.gitconfig ] && ddev exec --quiet --service $SERVICE command -v git > /dev/null 2>&1; then
+    if [ -e "$HOME"/.gitconfig ] && ddev exec --quiet --service "$SERVICE" command -v git > /dev/null 2>&1; then
         COUNT=0
         MAX_COUNT=5
-        until ddev exec --service $SERVICE "[ -e $HOME/.gitconfig ]" 2> /dev/null || [ $COUNT -gt $MAX_COUNT ]; do
-            ((COUNT=$COUNT+1))
+        until ddev exec --service "$SERVICE" "[ -e $HOME/.gitconfig ]" 2> /dev/null || [ $COUNT -gt $MAX_COUNT ]; do
+            COUNT=$((COUNT+1))
             sleep 1
         done
 
-        ddev exec --service $SERVICE git config --global core.autocrlf input
-        ddev exec --service $SERVICE git config --global safe.directory "\*"
+        ddev exec --service "$SERVICE" git config --global core.autocrlf input
+        ddev exec --service "$SERVICE" git config --global safe.directory "\*"
     fi
 fi

--- a/commands/host/code
+++ b/commands/host/code
@@ -37,20 +37,23 @@ if [[ ${CODE_CONTAINER+x} ]]; then
     # Remove DDEV's default .gitconfig file to allow DEV Containers extension to perform default behavior. https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials
     if [ -e "$HOME"/.gitconfig ] && ddev exec --quiet --service "$SERVICE" command -v git > /dev/null 2>&1; then
         ddev exec --quiet --service "$SERVICE" rm -f "$HOME"/.gitconfig
+        DDEV_GITCONFIG_EXISTS=0
+    else
+        DDEV_GITCONFIG_EXISTS=1
     fi
     
     ${CODE_EXECUTABLE} --folder-uri "vscode-remote://attached-container+$(printf "%s" "$CODE_CONTAINER" | od -A n -t x1 | sed 's/ *//g' | tr -d '\n')${CODE_PATH}"
 
     # Wait for VSCode to finish copying .gitconfig and then re-add DDEV default configs.
-    if [ -e "$HOME"/.gitconfig ] && ddev exec --quiet --service "$SERVICE" command -v git > /dev/null 2>&1; then
+    if [ $DDEV_GITCONFIG_EXISTS -eq 0 ]; then
         COUNT=0
         MAX_COUNT=5
+        sleep 1
         until ddev exec --service "$SERVICE" "[ -e $HOME/.gitconfig ]" 2> /dev/null || [ $COUNT -gt $MAX_COUNT ]; do
             COUNT=$((COUNT+1))
             sleep 1
         done
 
-        ddev exec --service "$SERVICE" git config --global core.autocrlf input
-        ddev exec --service "$SERVICE" git config --global safe.directory "\*"
+        ddev exec --service "$SERVICE" "git config --global core.autocrlf input; git config --global safe.directory \"*\""
     fi
 fi


### PR DESCRIPTION
## The Issue

When using VSCode's git functionality with this add-on, you are using git within the container. DDEV's global git configs set your username to "DDEV" and email to "nobody@example.com". If creates confusion about who is contributing in a multi-contributor project, or may just be annoying for solo project.

## How This PR Solves The Issue

VSCode's Dev Containers extension, by default, will copy your host's global config into the container when VSCode starts up, if a global config does not already exist in the container. This PR will:
1. Delete the container's `$HOME/.gitconfig`, if one exists on the host system
2.  Start VSCode
3. Wait for the new `$HOME/.gitconfig` to appear in the container (or timeout) and then append DDEV's non-user-specific settings

## Manual Testing Instructions

Before starting
- Close down VSCode for the test project
- Confirm you have global git configs set for user.name and user.email

```bash
ddev start
ddev add-on get https://github.com/tyler36/ddev-vscode-devcontainer/tarball/refs/pull/16/head
ddev code
ddev exec git config --global --list
```
Confirm your global git config for user.name and user.email are displayed in the output

## Release/Deployment Notes

This should have no negative impacts on existing user experience.
